### PR TITLE
refs #62 Fixed connection loss message not sent when connection to bo…

### DIFF
--- a/include/hnzconnection.h
+++ b/include/hnzconnection.h
@@ -114,6 +114,11 @@ class HNZConnection {
    */
   GiStatus getGiStatus();
 
+  /**
+   * Returns mutex used to protect the active and passive path
+   */
+  std::recursive_mutex& getPathMutex() { return m_path_mutex; }
+
  private:
   std::shared_ptr<HNZPath> m_active_path;
   std::shared_ptr<HNZPath> m_passive_path;

--- a/include/hnzpath.h
+++ b/include/hnzpath.h
@@ -86,6 +86,12 @@ class HNZPath {
   vector<vector<unsigned char>> getData();
 
   /**
+   * Is the HNZ connection with the PA established and still alive?
+   * @return true if connected, false otherwise
+   */
+  bool isHNZConnected() { return (m_protocol_state == CONNECTED) && isConnected(); };
+
+  /**
    * Is the TCP connection with the PA established and still alive?
    * @return true if connected, false otherwise
    */
@@ -324,7 +330,22 @@ class HNZPath {
    */
   void m_send_time_setting();
 
+  /**
+   * Go to the CONNECTED statue of the HNZ connection
+   */
   void m_go_to_connected();
+
+  /**
+   * Get the other path if any
+   * @return Second HNZ path, or nullptr if no other path defined
+   */
+  std::shared_ptr<HNZPath> m_getOtherPath();
+
+  /**
+   * Tells if the HNZ connection is fully established and active on the other path
+   * @return True if the connection is established, false if not established or no other path defined
+   */
+  bool m_isOtherPathHNZConnected();
 };
 
 #endif

--- a/src/hnzconnection.cpp
+++ b/src/hnzconnection.cpp
@@ -248,7 +248,7 @@ void HNZConnection::switchPath() {
     HnzUtility::log_info("New active path is " + m_active_path->getName());
 
     // When switching path, update connection status accordingly
-    if (m_active_path->getProtocolState() == CONNECTED) {
+    if (m_active_path->isHNZConnected()) {
       updateConnectionStatus(ConnectionStatus::STARTED);
     }
     else {

--- a/src/hnzpath.cpp
+++ b/src/hnzpath.cpp
@@ -97,17 +97,17 @@ void HNZPath::connect() {
       }
       // Connection established, go to main loop
       return;
-    } else {
-      HnzUtility::log_warn(m_name_log +
-                                " Error in connection, retrying in " +
-                                to_string(RETRY_CONN_DELAY) + "s ...");
-      if (m_hnz_connection) {
-        // If connection failed, try to switch path
-        std::lock_guard<std::recursive_mutex> lock(m_hnz_connection->getPathMutex());
-        if (m_is_active_path) m_hnz_connection->switchPath();
-      }
-      this_thread::sleep_for(std::chrono::seconds(RETRY_CONN_DELAY));
     }
+    
+    HnzUtility::log_warn(m_name_log +
+                              " Error in connection, retrying in " +
+                              to_string(RETRY_CONN_DELAY) + "s ...");
+    if (m_hnz_connection) {
+      // If connection failed, try to switch path
+      std::lock_guard<std::recursive_mutex> lock(m_hnz_connection->getPathMutex());
+      if (m_is_active_path) m_hnz_connection->switchPath();
+    }
+    this_thread::sleep_for(std::chrono::seconds(RETRY_CONN_DELAY));
   }
 }
 


### PR DESCRIPTION
…th path (A and B) was lost simultaneously.

Fixed several potential misbehavior in HNZPath due to the lack of mutex when accessing information about the active path. Added a unit test to cover the multiple path connection loss.

Closes #62 