### PR TITLE
refs #PMP2-278 Applied the following changes:

### DIFF
--- a/include/hnz.h
+++ b/include/hnz.h
@@ -115,8 +115,9 @@ class HNZ {
    *
    * @param count Number of parameters
    * @param params Array of parameters
+   * @return 0 if command was sent to HNZ device, 1 if command syntax error, 2 if command could not be sent to HNZ device (connection error)
    */
-  bool processCommandOperation(int count, PLUGIN_PARAMETER** params);
+  int processCommandOperation(int count, PLUGIN_PARAMETER** params);
 
   /**
    * Utility function used to store the content of a frame as a human readable hex string

--- a/include/hnzpath.h
+++ b/include/hnzpath.h
@@ -309,14 +309,16 @@ class HNZPath {
    * NS) will be added by this method.
    * @param msg payload
    * @param size nubmer of byte in the payload
+   * @return True if the message was sent, false if it was discarded
    */
-  void m_sendInfo(unsigned char* msg, unsigned long size);
+  bool m_sendInfo(unsigned char* msg, unsigned long size);
 
   /**
    * Send a message immediately
    * @param message The message to send
+   * @return True if the message was sent, false if it was discarded
    */
-  void m_sendInfoImmediately(Message message);
+  bool m_sendInfoImmediately(Message message);
 
   /**
    * Send a date configuration message

--- a/include/hnzpath.h
+++ b/include/hnzpath.h
@@ -346,6 +346,16 @@ class HNZPath {
    * @return True if the connection is established, false if not established or no other path defined
    */
   bool m_isOtherPathHNZConnected();
+
+  /**
+   * Called after sending a Command to store its information until a ACK is received, if the command was actually sent
+   * @param type Type of command: TC or TVC
+   * @param sent True if the command was sent to the HNZ device, else false
+   * @param address Destination address of the command
+   * @param value Value of the command
+   * @param beforeLog Prefix for the log messages produced by this function
+   */
+  void m_registerCommandIfSent(const std::string& type, bool sent, unsigned char address, int value, const std::string& beforeLog);
 };
 
 #endif

--- a/src/hnzpath.cpp
+++ b/src/hnzpath.cpp
@@ -92,6 +92,20 @@ std::string convert_message_to_str(const Message& message) {
   return stream.str();
 }
 
+/**
+ * Helper method to convert a list of message into something readable for logs.
+ */
+std::string convert_messages_to_str(const deque<Message>& messages) {
+  std::string msgStr;
+  for(const Message& msg: messages) {
+    if (msgStr.size() > 0){
+      msgStr += ", ";
+    }
+    msgStr += "[" + convert_message_to_str(msg) + "]";
+  }
+  return msgStr;
+}
+
 void HNZPath::connect() {
   std::string beforeLog = HnzUtility::NamePlugin + " - HNZPath::connect - " + m_name_log;
   // Reinitialize those variables in case of reconnection
@@ -258,24 +272,12 @@ void HNZPath::go_to_connection() {
 
   // Discard unacknowledged messages and messages waiting to be sent
   if (!msg_sent.empty()) {
-    std::string sentMsgStr;
-    for(const Message& sentMsg: msg_sent) {
-      if (sentMsgStr.size() > 0){
-        sentMsgStr += ", ";
-      }
-      sentMsgStr += "[" + convert_message_to_str(sentMsg) + "]";
-    }
+    std::string sentMsgStr = convert_messages_to_str(msg_sent);
     HnzUtility::log_debug(beforeLog + " Discarded unacknowledged messages sent: " + sentMsgStr);
     msg_sent.clear();
   }
   if (!msg_waiting.empty()) {
-    std::string waitingMsgStr;
-    for(const Message& waitingMsg: msg_waiting) {
-      if (waitingMsgStr.size() > 0){
-        waitingMsgStr += ", ";
-      }
-      waitingMsgStr += "[" + convert_message_to_str(waitingMsg) + "]";
-    }
+    std::string waitingMsgStr = convert_messages_to_str(msg_waiting);
     HnzUtility::log_debug(beforeLog + " Discarded messages waiting to be sent: " + waitingMsgStr);
     msg_waiting.clear();
   }  
@@ -589,13 +591,7 @@ bool HNZPath::m_sendInfo(unsigned char* msg, unsigned long size) {
   if (msg_sent.size() < m_anticipation_ratio) {
     return m_sendInfoImmediately(message);
   } else {
-    std::string waitingMsgStr;
-    for(const Message& waitingMsg: msg_sent) {
-      if (waitingMsgStr.size() > 0){
-        waitingMsgStr += ", ";
-      }
-      waitingMsgStr += "[" + convert_message_to_str(waitingMsg) + "]";
-    }
+    std::string waitingMsgStr = convert_messages_to_str(msg_sent);
     HnzUtility::log_debug(beforeLog + " Anticipation ratio reached (" + std::to_string(m_anticipation_ratio) + "), message ["
                         + convert_data_to_str(msg, static_cast<int>(size)) + "] will be delayed. Messages waiting: "
                         + waitingMsgStr);
@@ -610,7 +606,7 @@ bool HNZPath::m_sendInfoImmediately(Message message) {
   int size = message.payload.size();
   if (m_protocol_state != CONNECTED) {
     HnzUtility::log_debug(beforeLog + " Connection is not yet fully established, discarding message ["
-                        + convert_data_to_str(msg, static_cast<int>(size)) + "]");
+                        + convert_data_to_str(msg, size) + "]");
     return false;
   }
 

--- a/tests/test_hnz.cpp
+++ b/tests/test_hnz.cpp
@@ -2607,7 +2607,7 @@ TEST_F(HNZTest, NoMessageBufferedIfConnectionLost) {
   TCframe = findFrameWithId(frames, 0x19);
   ASSERT_EQ(TCframe.get(), nullptr) << "TC was sent after reconnection: " << BasicHNZServer::frameToStr(TCframe);
   TVCframe = findFrameWithId(frames, 0x1a);
-  ASSERT_EQ(TVCframe.get(), nullptr) << "TVC was sent after reconnection: " << BasicHNZServer::frameToStr(TCframe);
+  ASSERT_EQ(TVCframe.get(), nullptr) << "TVC was sent after reconnection: " << BasicHNZServer::frameToStr(TVCframe);
 
   // Stop sending automatic ack (RR) in response to messages from south plugin
   server->disableAcks(true);
@@ -2653,5 +2653,5 @@ TEST_F(HNZTest, NoMessageBufferedIfConnectionLost) {
   TCframe = findFrameWithId(frames, 0x19);
   ASSERT_EQ(TCframe.get(), nullptr) << "TC 2 was sent after reconnection: " << BasicHNZServer::frameToStr(TCframe);
   TVCframe = findFrameWithId(frames, 0x1a);
-  ASSERT_EQ(TVCframe.get(), nullptr) << "TVC 2 was sent after reconnection: " << BasicHNZServer::frameToStr(TCframe);
+  ASSERT_EQ(TVCframe.get(), nullptr) << "TVC 2 was sent after reconnection: " << BasicHNZServer::frameToStr(TVCframe);
 }


### PR DESCRIPTION
* Removed all messages waiting to be sent to the HNZ device when connection is lost.
* Ensured that no message received addressed to the HNZ device while connection is not established will be buffered.
* Improved log messages displayed when an information message is rejected.
* Added unit test for this new behavior.