### PR TITLE
PMP2-385 Add UTC time as a new setting

### DIFF
--- a/include/hnz.h
+++ b/include/hnz.h
@@ -135,7 +135,7 @@ class HNZ {
    * @param ts Time in group of 10 milliseconds in current section of day
    * @return an epoch timestamp in milliseconds
    */
-  static unsigned long getEpochMsTimestamp(std::chrono::time_point<std::chrono::high_resolution_clock> dateTime,
+  static unsigned long getEpochMsTimestamp(std::chrono::time_point<std::chrono::system_clock> dateTime,
                                             unsigned char daySection, unsigned int ts);
 
   /**

--- a/include/hnzconf.h
+++ b/include/hnzconf.h
@@ -49,6 +49,7 @@ constexpr char CMD_RECV_TIMEOUT[] = "cmd_recv_timeout";
 constexpr char BULLE_TIME[] = "bulle_time";
 constexpr char SOUTH_MONITORING[] = "south_monitoring";
 constexpr char SOUTH_MONITORING_ASSET[] = "asset";
+constexpr char MODULO_USE_UTC[] = "modulo_use_utc";
 
 constexpr char JSON_EXCHANGED_DATA_NAME[] = "exchanged_data";
 constexpr char DATAPOINTS[] = "datapoints";
@@ -267,6 +268,13 @@ class HNZConf {
    */
   unsigned int get_bulle_time() const { return m_bulle_time; }
 
+    /**
+   * Get the prefered reference time for messages timestamps (UTC or local time)
+   *
+   * @return wheter to use UTC time or local time
+   */
+  bool get_use_utc() const { return m_use_utc; }
+
   /**
    * Get the "asset" name for south plugin monitoring event
    *
@@ -337,6 +345,7 @@ class HNZConf {
   unsigned int m_c_ack_time = 0;
   long long int m_cmd_recv_timeout = 0;
   unsigned int m_bulle_time = 0;
+  bool m_use_utc = false;
 
   std::string m_connx_status = "";
   unsigned int m_lastTSAddr = 0;
@@ -360,6 +369,7 @@ class HNZConf {
   static bool m_retrieve(const Value &json, const char *key, BulleFormat *target);
   static bool m_retrieve(const Value &json, const char *key, GIScheduleFormat *target);
   static bool m_retrieve(const Value &json, const char *key, long long int *target, long long int def);
+  static bool m_retrieve(const Value &json, const char *key, bool *target, bool def);
 };
 
 #endif

--- a/include/hnzpath.h
+++ b/include/hnzpath.h
@@ -262,6 +262,7 @@ class HNZPath {
   BulleFormat m_test_msg_receive;  // Payload of received BULLE
   BulleFormat m_test_msg_send;     // Payload of sent BULLE
   long long c_ack_time_max = 0;  // Max time to wait before receving a acknowledgement for a control command (in ms)
+  bool m_use_utc = false;
 
   // HNZ protocol related variable
   int m_nr = 0;   // Number in reception

--- a/include/hnzpath.h
+++ b/include/hnzpath.h
@@ -261,8 +261,8 @@ class HNZPath {
   unsigned int m_bulle_time = 0; // time in seconds before sending a BULLE mesage when no message have been sent on this path
   BulleFormat m_test_msg_receive;  // Payload of received BULLE
   BulleFormat m_test_msg_send;     // Payload of sent BULLE
+  bool m_use_utc = false; // Use UTC time in date and time init messages
   long long c_ack_time_max = 0;  // Max time to wait before receving a acknowledgement for a control command (in ms)
-  bool m_use_utc = false;
 
   // HNZ protocol related variable
   int m_nr = 0;   // Number in reception

--- a/src/hnz.cpp
+++ b/src/hnz.cpp
@@ -354,15 +354,15 @@ void HNZ::m_handleTSCE(vector<Reading>& readings, const vector<unsigned char>& d
   unsigned int ts_s = data[2] & 0x1;          // S bit
   unsigned int ts_c = (data[2] >> 1) & 0x1;   // C bit
   // Using C time (C++11 limitations conversion to local time)
-  time_t now = time(0);
-  tm* time_struct_real = new tm();
-  m_hnz_conf->get_use_utc() ? gmtime_r(&now, time_struct_real) : localtime_r(&now, time_struct_real);
-  unsigned long epochMs = getEpochMsTimestamp(std::chrono::system_clock::from_time_t(mktime(time_struct_real)), m_daySection, ts);
+  time_t now = time(nullptr);
+  auto time_struct_real = tm();
+  m_hnz_conf->get_use_utc() ? gmtime_r(&now, &time_struct_real) : localtime_r(&now, &time_struct_real);
+  auto epochMs = getEpochMsTimestamp(std::chrono::system_clock::from_time_t(mktime(&time_struct_real)), m_daySection, ts);
 
   // Always timestamp with UTC time --------
-  tm* time_struct_utc = new tm();
-  gmtime_r(&now, time_struct_utc);
-  unsigned long real_utc_offset_ms = static_cast<unsigned long>((mktime(time_struct_real) - mktime(time_struct_utc))) * 1000;
+  auto time_struct_utc = tm();
+  gmtime_r(&now, &time_struct_utc);
+  auto real_utc_offset_ms = static_cast<unsigned long>((mktime(&time_struct_real) - mktime(&time_struct_utc))) * 1000;
   // ----------------------------------------
 
   ReadingParameters params;

--- a/src/hnzconf.cpp
+++ b/src/hnzconf.cpp
@@ -51,6 +51,8 @@ void HNZConf::importConfigJson(const string &json) {
   if (m_check_object(info, APP_LAYER)) {
     const Value &conf = info[APP_LAYER];
     is_complete &= m_importApplicationLayer(conf);
+    // Use UTC time instead of local time, default false.
+    m_retrieve(conf, MODULO_USE_UTC, &m_use_utc, false);
   } else {
     is_complete = false;
   }
@@ -456,6 +458,21 @@ bool HNZConf::m_retrieve(const Value &json, const char *key, long long int *targ
       return false;
     }
     *target = json[key].GetInt64();
+  }
+  return true;
+}
+
+bool HNZConf::m_retrieve(const Value &json, const char *key, bool *target, bool def) {
+  std::string beforeLog = HnzUtility::NamePlugin + " - HNZConf::m_retrieve - ";
+  if (!json.HasMember(key)) {
+    *target = def;
+  } else {
+    if (!json[key].IsBool()) {
+      string s = key;
+      HnzUtility::log_error(beforeLog + "Error with the field " + s + ", the value is not a bool.");
+      return false;
+    }
+    *target = json[key].GetBool();
   }
   return true;
 }

--- a/src/hnzconnection.cpp
+++ b/src/hnzconnection.cpp
@@ -149,7 +149,7 @@ void HNZConnection::notifyGIsent(){
   }
   m_gi_repeat++;
   m_gi_start_time = std::chrono::duration_cast<std::chrono::milliseconds>(
-                      std::chrono::high_resolution_clock::now().time_since_epoch())
+                      std::chrono::system_clock::now().time_since_epoch())
                       .count();
 }
 
@@ -227,7 +227,7 @@ void HNZConnection::m_check_timer(HNZPath* path) {
   }
 
   if(path->getProtocolState() == ProtocolState::CONNECTED){
-    long long now = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now().time_since_epoch()).count();
+    long long now = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
     long long ms_since_connected = now - path->getLastConnected();
     if(path->getLastConnected() > 0 && ms_since_connected >= m_repeat_timeout){
       if(path->getConnectionState() == ConnectionState::ACTIVE && m_sendInitNexConnection){
@@ -299,7 +299,7 @@ void HNZConnection::m_check_command_timer(HNZPath* path) {
 void HNZConnection::m_update_current_time() {
   uint64_t prevTimeMs = m_current;
   m_current =
-      std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now().time_since_epoch())
+      std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch())
           .count();
   m_elapsedTimeMs = m_current - prevTimeMs;
 }

--- a/src/hnzpath.cpp
+++ b/src/hnzpath.cpp
@@ -781,13 +781,13 @@ void HNZPath::m_send_date_setting() {
   std::string beforeLog = HnzUtility::NamePlugin + " - HNZPath::m_send_date_setting - " + m_name_log;
   unsigned char msg[4];
   // Using C time (C++11 limitations conversion to local time)
-  time_t now = time(0);
-  tm* time_struct = new tm();
-  m_use_utc ? gmtime_r(&now, time_struct) : localtime_r(&now, time_struct);
+  time_t now = time(nullptr);
+  tm time_struct = tm();
+  m_use_utc ? gmtime_r(&now, &time_struct) : localtime_r(&now, &time_struct);
   msg[0] = SETDATE_CODE;
-  msg[1] = time_struct->tm_mday;
-  msg[2] = time_struct->tm_mon + 1;
-  msg[3] = time_struct->tm_year % 100;
+  msg[1] = time_struct.tm_mday;
+  msg[2] = time_struct.tm_mon + 1;
+  msg[3] = time_struct.tm_year % 100;
   bool sent = m_sendInfo(msg, sizeof(msg));
   HnzUtility::log_info(beforeLog + " Time setting " + (sent?"sent":"discarded") + " : " + to_string((int)msg[1]) + "/" +
                                   to_string((int)msg[2]) + "/" + to_string((int)msg[3]));
@@ -797,10 +797,10 @@ void HNZPath::m_send_time_setting() {
   std::string beforeLog = HnzUtility::NamePlugin + " - HNZPath::m_send_time_setting - " + m_name_log;
   // Using C time (C++11 limitations conversion to local time)
   time_t now = time(0);
-  tm* time_struct = new tm();
-  m_use_utc ? gmtime_r(&now, time_struct) : localtime_r(&now, time_struct);
+  tm time_struct = tm();
+  m_use_utc ? gmtime_r(&now, &time_struct) : localtime_r(&now, &time_struct);
   long int ms_since_epoch = std::chrono::duration_cast<std::chrono::milliseconds>(
-              std::chrono::system_clock::from_time_t(mktime(time_struct)).time_since_epoch()).count();
+              std::chrono::system_clock::from_time_t(mktime(&time_struct)).time_since_epoch()).count();
   long int ms_today = ms_since_epoch % 86400000;
   long int mod10m = ms_today / 600000;
   long int frac = (ms_today - (mod10m * 600000)) / 10;

--- a/src/hnzpath.cpp
+++ b/src/hnzpath.cpp
@@ -36,6 +36,7 @@ HNZPath::HNZPath(const std::shared_ptr<HNZConf> hnz_conf, HNZConnection* hnz_con
                   m_bulle_time(hnz_conf->get_bulle_time()),
                   m_test_msg_receive(hnz_conf->get_test_msg_receive()),
                   m_test_msg_send(hnz_conf->get_test_msg_send()),
+                  m_use_utc(hnz_conf->get_use_utc()),
                   // Command settings
                   c_ack_time_max(hnz_conf->get_c_ack_time() * 1000)
 {
@@ -89,7 +90,7 @@ void HNZPath::stopTCP(){
 void HNZPath::resetSarmCounters(){
   m_nbr_sarm_sent = 0;
   // Reset time from last message received to prevent instant timeout
-  m_last_msg_time = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now().time_since_epoch()).count();
+  m_last_msg_time = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
 }
 
 void HNZPath::resetOutputVariables(){
@@ -100,7 +101,7 @@ void HNZPath::resetOutputVariables(){
 
 void HNZPath::resetInputVariables(){
   m_nr = 0;
-  m_last_msg_time = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now().time_since_epoch()).count();
+  m_last_msg_time = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
 }
 
 /**
@@ -180,7 +181,7 @@ void HNZPath::resolveProtocolStateConnected(){
   }
   HnzUtility::log_debug(beforeLog + " HNZ Connection initialized !!");
 
-  m_last_connected = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now().time_since_epoch()).count();
+  m_last_connected = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
 }
 
 void HNZPath::resolveProtocolStateConnection(){
@@ -215,7 +216,7 @@ void HNZPath::connect() {
   std::string beforeLog = HnzUtility::NamePlugin + " - HNZPath::connect - " + m_name_log;
   // Reinitialize those variables in case of reconnection
   
-  m_last_msg_time = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now().time_since_epoch()).count();
+  m_last_msg_time = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
   m_last_msg_sent_time = m_last_msg_time;
   m_is_running = true;
   // Loop until connected (make sure we exit if connection is shutting down)
@@ -283,7 +284,7 @@ void HNZPath::m_manageHNZProtocolConnection() {
       std::lock(m_protocol_state_mutex, m_hnz_connection->getPathMutex()); // Lock both mutexes simultaneously
       std::lock_guard<std::recursive_mutex> lock(m_protocol_state_mutex, std::adopt_lock);
       std::lock_guard<std::recursive_mutex> lock2(m_hnz_connection->getPathMutex(), std::adopt_lock);
-      long long now = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now().time_since_epoch()).count();
+      long long now = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
       sleep = m_manageHNZProtocolState(now);
     }
     // lock mutex (preparation to wait in cond. var.)
@@ -546,7 +547,7 @@ void HNZPath::m_receivedSARM() {
   std::string beforeLog = HnzUtility::NamePlugin + " - HNZPath::m_receivedSARM - " + m_name_log;
   m_sendUA();
 
-  long long now = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now().time_since_epoch()).count();
+  long long now = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
   if(now - m_last_connected > m_repeat_timeout){
     protocolStateTransition(ConnectionEvent::RECEIVED_SARM);
   } else {
@@ -559,7 +560,7 @@ void HNZPath::m_receivedUA() {
 }
 
 void HNZPath::m_receivedBULLE() {
-  m_last_msg_time = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now().time_since_epoch()).count();
+  m_last_msg_time = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
 }
 
 bool HNZPath::m_receivedRR(int nr, bool repetition) {
@@ -624,7 +625,7 @@ void HNZPath::m_NRAccepted(int nr) {
   // Waiting for other RR, set timer
   if (!msg_sent.empty())
     last_sent_time = std::chrono::duration_cast<std::chrono::milliseconds>(
-                          std::chrono::high_resolution_clock::now().time_since_epoch())
+                          std::chrono::system_clock::now().time_since_epoch())
                           .count();
 
   // Sent message in waiting queue
@@ -642,7 +643,7 @@ void HNZPath::m_sendSARM() {
   m_sendFrame(msg, sizeof(msg));
   HnzUtility::log_info(beforeLog + " SARM sent [" + to_string(m_nbr_sarm_sent + 1) + " / " + to_string(m_max_sarm) + "]");
   m_nbr_sarm_sent++;
-  m_last_sarm_sent_time = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now().time_since_epoch()).count();
+  m_last_sarm_sent_time = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
 }
 
 void HNZPath::m_sendUA() {
@@ -694,7 +695,7 @@ bool HNZPath::m_sendRR(bool repetition, int ns, int nr) {
   }
 
   // Update timer
-  m_last_msg_time = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now().time_since_epoch()).count();
+  m_last_msg_time = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
   return true;
 }
 
@@ -741,7 +742,7 @@ bool HNZPath::m_sendInfoImmediately(Message message) {
   // Set timer if there is not other message sent waiting for confirmation
   if (msg_sent.empty())
     last_sent_time =
-        std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now().time_since_epoch())
+        std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch())
             .count();
 
   message.ns = m_ns;
@@ -768,7 +769,7 @@ void HNZPath::sendBackInfo(Message& message) {
   m_sendFrame(msgWithNrNs, sizeof(msgWithNrNs));
 
   last_sent_time =
-      std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now().time_since_epoch())
+      std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch())
           .count();
   
   HnzUtility::log_debug(beforeLog + " Resent information frame: " +
@@ -779,8 +780,10 @@ void HNZPath::sendBackInfo(Message& message) {
 void HNZPath::m_send_date_setting() {
   std::string beforeLog = HnzUtility::NamePlugin + " - HNZPath::m_send_date_setting - " + m_name_log;
   unsigned char msg[4];
+  // Using C time (C++11 limitations conversion to local time)
   time_t now = time(0);
-  tm* time_struct = gmtime(&now);
+  tm* time_struct = new tm();
+  m_use_utc ? gmtime_r(&now, time_struct) : localtime_r(&now, time_struct);
   msg[0] = SETDATE_CODE;
   msg[1] = time_struct->tm_mday;
   msg[2] = time_struct->tm_mon + 1;
@@ -792,9 +795,12 @@ void HNZPath::m_send_date_setting() {
 
 void HNZPath::m_send_time_setting() {
   std::string beforeLog = HnzUtility::NamePlugin + " - HNZPath::m_send_time_setting - " + m_name_log;
+  // Using C time (C++11 limitations conversion to local time)
+  time_t now = time(0);
+  tm* time_struct = new tm();
+  m_use_utc ? gmtime_r(&now, time_struct) : localtime_r(&now, time_struct);
   long int ms_since_epoch = std::chrono::duration_cast<std::chrono::milliseconds>(
-                          std::chrono::high_resolution_clock::now().time_since_epoch())
-                          .count();
+              std::chrono::system_clock::from_time_t(mktime(time_struct)).time_since_epoch()).count();
   long int ms_today = ms_since_epoch % 86400000;
   long int mod10m = ms_today / 600000;
   long int frac = (ms_today - (mod10m * 600000)) / 10;
@@ -870,7 +876,7 @@ void HNZPath::m_registerCommandIfSent(const std::string& type, bool sent, int ad
   // Add the command in the list of commend sent (to check ACK later)
   Command_message cmd;
   cmd.timestamp_max = std::chrono::duration_cast<std::chrono::milliseconds>(
-                          std::chrono::high_resolution_clock::now().time_since_epoch())
+                          std::chrono::system_clock::now().time_since_epoch())
                           .count() +
                       c_ack_time_max;
   cmd.type = type;
@@ -881,7 +887,7 @@ void HNZPath::m_registerCommandIfSent(const std::string& type, bool sent, int ad
 
 void HNZPath::m_sendFrame(unsigned char *msg, unsigned long msgSize, bool usePAAddr /*= false*/) {
   m_hnz_client->createAndSendFr(usePAAddr ? m_address_PA : m_address_ARP, msg, static_cast<int>(msgSize));
-  m_last_msg_sent_time = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now().time_since_epoch()).count();
+  m_last_msg_sent_time = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
 }
 
 bool HNZPath::isBULLE(const unsigned char* msg, unsigned long size) const{

--- a/tests/test_hnz.cpp
+++ b/tests/test_hnz.cpp
@@ -976,11 +976,11 @@ class ProtocolStateHelper{
     std::shared_ptr<BasicHNZServer> _server;
 };
 
-// TEST_F(HNZTest, TCPConnectionOnePathOK) {
-//   ServersWrapper wrapper(0x05, getNextPort());
-//   BasicHNZServer* server = wrapper.server1().get();
-//   ASSERT_NE(server, nullptr) << "Something went wrong. Connection is not established in 10s...";
-// }
+TEST_F(HNZTest, TCPConnectionOnePathOK) {
+  ServersWrapper wrapper(0x05, getNextPort());
+  BasicHNZServer* server = wrapper.server1().get();
+  ASSERT_NE(server, nullptr) << "Something went wrong. Connection is not established in 10s...";
+}
 
 TEST_F(HNZTest, ReceivingTSCEMessages) {
   ServersWrapper wrapper(0x05, getNextPort());

--- a/tests/test_hnz.cpp
+++ b/tests/test_hnz.cpp
@@ -976,11 +976,11 @@ class ProtocolStateHelper{
     std::shared_ptr<BasicHNZServer> _server;
 };
 
-TEST_F(HNZTest, TCPConnectionOnePathOK) {
-  ServersWrapper wrapper(0x05, getNextPort());
-  BasicHNZServer* server = wrapper.server1().get();
-  ASSERT_NE(server, nullptr) << "Something went wrong. Connection is not established in 10s...";
-}
+// TEST_F(HNZTest, TCPConnectionOnePathOK) {
+//   ServersWrapper wrapper(0x05, getNextPort());
+//   BasicHNZServer* server = wrapper.server1().get();
+//   ASSERT_NE(server, nullptr) << "Something went wrong. Connection is not established in 10s...";
+// }
 
 TEST_F(HNZTest, ReceivingTSCEMessages) {
   ServersWrapper wrapper(0x05, getNextPort());
@@ -3962,6 +3962,7 @@ TEST_F(HNZTest, timeSettingsUseUTC) {
   ASSERT_GE(time_frame->usLgBuffer, 6);
 
   ASSERT_GE(time_frame->usLgBuffer, 6);
+  bool passed_modulo = (time_frame->aubTrame[3] == (mod10m + 1) % 144);
   mod10m = time_frame->aubTrame[3];
   frac = (time_frame->aubTrame[4] << 8) + time_frame->aubTrame[5];
   long int total_seconds_utc = mod10m * 600 + frac / 100;
@@ -3988,6 +3989,8 @@ TEST_F(HNZTest, timeSettingsUseUTC) {
   int64_t do_ts_utc = getIntValue(getChild(*data_object, "do_ts"));
   if(HasFatalFailure()) return;
   // ------------------------------------------------------------------------------
+
+  do_ts_local += passed_modulo ? 600000 : 0; // Prevent test from failing if the modulo changed between ts local and utc ...
   debug_print("Values found : do_ts_local = %ld, do_ts_utc = %ld, expectedEpochMs_utc = %ld", do_ts_local, do_ts_utc, expectedEpochMs_utc);
   ASSERT_TRUE(do_ts_local == do_ts_utc && do_ts_local == expectedEpochMs_utc) << "Status points timestamps should always be using UTC time.";
 }


### PR DESCRIPTION
Default time for Status Points timestamps and initialization date/time messages are now in local timezone (CET/CEST).
A new setting of the protocol stack is used to set time to UTC :  "application_layer": { "modulo_use_tc" : true/false }  (default false)

Use of std::chrono::high_resolution_clock has been replaced with std::chrono::system_cloc. The first is "often just an alias for std::chrono::steady_clock or std::chrono::system_clock, but which one it is depends on the library or configuration." [[1]](https://en.cppreference.com/w/cpp/chrono/high_resolution_clock)
The latter can be cast to [std::time_t](https://en.cppreference.com/w/cpp/chrono/c/time_t). 

Note : Due to using C++11 with glibc==2.11, dating errors will appear starting from January 19th 2038. (see [wikipedia](https://en.wikipedia.org/wiki/Year_2038_problem)).